### PR TITLE
Close connection before stopping mongo

### DIFF
--- a/packages/waves-server-db/test/storageSetup.js
+++ b/packages/waves-server-db/test/storageSetup.js
@@ -53,8 +53,10 @@ class StorageSetup {
   }
 
   async after(storage) {
-    await this.cleanTestDb()
+    /* Ensure that storage is closed before cleaning test db.
+     * See https://github.com/Automattic/mongoose/issues/1807 */
     await this.storage.close()
+    await this.cleanTestDb()
   }
 
   async cleanTestDb() {


### PR DESCRIPTION
Mongoose was keeping Node process alive in tests.

Closing the mongoose connection before stopping the
Mongo container reduces the runtime significantly.

See https://github.com/Automattic/mongoose/issues/1807

Output before change:

```
lerna success run Ran npm script 'test' in 1 package in 5.3s:
lerna success - waves-server-db
```

Output after change:

```
lerna success run Ran npm script 'test' in 1 package in 39.6s:
lerna success - waves-server-db
```